### PR TITLE
build: add github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [ 1.15, 1.16, 1.17 ]
+        os: [ ubuntu-20.04, macos-10.5, windows-2019 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test --cover -v ./...
+      - name: Build
+        run: go build -v ./...


### PR DESCRIPTION
Add Github Actions to build and test the code.

I tested the action with [act](https://github.com/nektos/act) on ubuntu 20.04 and go 1.17.

![render1633704504615](https://user-images.githubusercontent.com/686305/136578207-6b2f483b-de11-48c7-b759-451c8066fcb8.gif)
