### PR TITLE
build: replace satori/go.uuid by gofrs/uuid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ 1.15, 1.16, 1.17 ]
-        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        go-version: [ 1.15, 1.16, 1.17, 1.18, 1.19 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/kumojin/go-uuid
 go 1.15
 
 require (
-	github.com/satori/go.uuid v1.2.0
+	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
+github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/ordered_uuid.go
+++ b/ordered_uuid.go
@@ -1,14 +1,20 @@
 package uuid
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 // NewOrdered creates a new UUIDv1 and converts it to an OrderedUUID
-//  v1 UUID: aaaabbbb-cccc-dddd-1234-567890123456
-//  transposed: ddddcccc-aaaa-bbbb-1234-567890123456
+//
+//	v1 UUID: aaaabbbb-cccc-dddd-1234-567890123456
+//	transposed: ddddcccc-aaaa-bbbb-1234-567890123456
 func NewOrdered() UUID {
-	u := uuid.NewV1()
+	u, err := uuid.NewV1()
+	if err != nil {
+		return UUID{
+			Valid: false,
+		}
+	}
 
 	return FromUUIDv1(u)
 }

--- a/ordered_uuid_test.go
+++ b/ordered_uuid_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/uuid.go
+++ b/uuid.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 // UUIDSize is the size of the uuid
@@ -20,7 +20,12 @@ type UUID struct {
 }
 
 func NewV1() UUID {
-	v1 := uuid.NewV1()
+	v1, err := uuid.NewV1()
+	if err != nil {
+		return UUID{
+			Valid: false,
+		}
+	}
 	u := UUID{
 		Valid: true,
 	}
@@ -29,7 +34,12 @@ func NewV1() UUID {
 }
 
 func NewV4() UUID {
-	v4 := uuid.NewV4()
+	v4, err := uuid.NewV4()
+	if err != nil {
+		return UUID{
+			Valid: false,
+		}
+	}
 	u := UUID{
 		Valid: true,
 	}
@@ -87,13 +97,16 @@ func (u *UUID) Scan(src interface{}) error {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // Following formats are supported:
-//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-//   "6ba7b8109dad11d180b400c04fd430c8"
+//
+//	"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//	"6ba7b8109dad11d180b400c04fd430c8"
+//
 // Supported UUID text representation follows:
-//   uuid := canonical | hashlike
-//   plain := canonical | hashlike
-//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
-//   hashlike := 12hexoct
+//
+//	uuid := canonical | hashlike
+//	plain := canonical | hashlike
+//	canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//	hashlike := 12hexoct
 func (u *UUID) UnmarshalText(text []byte) (err error) {
 	switch len(text) {
 	case 0:


### PR DESCRIPTION
Replace `github.com/satori/go.uuid` to `github.com/gofrs/uuid` because:
- `github.com/gofrs/uuid` is an actively maintained fork ([see fork reasons](https://github.com/gofrs/uuid/releases/tag/v2.0.0))
- `github.com/satori/go.uuid` is affected by [CVE-2021-3538](https://www.cve.org/CVERecord?id=CVE-2021-3538)

⚠️ This might need a major semver bump as it is probably a breaking change.