### PR TITLE
build: update dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* -text
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,16 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Run gofmt
-        id: gofmt
-        run: echo "::set-output name=GOFMT_RESULT::$(gofmt -l .)"
-      - name: Check gofmt errors
-        if: steps.gofmt.outputs.GOFMT_RESULT != ''
-        run: exit 1
+        uses: actions/checkout@v3
+      - name: Enforce standard format
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
+          args: --timeout 3m --enable=gofmt --verbose
       - name: Test
         run: go test --cover -v ./...
       - name: Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-uuid
 
+[![CI](https://github.com/kumojin/go-uuid/actions/workflows/ci.yml/badge.svg)](https://github.com/kumojin/go-uuid/actions/workflows/ci.yml)
+
 A package providing UUID v1, v4 and OrderedUUID with utility interface and function.
 
 ## What is an OrderedUUID?
@@ -15,12 +17,14 @@ This allows you to scan your struct with a UUID right from the database!
 Moreover, it is implementing the `encoding.TextUnmarshaler` and the `encoding.TextMarshaler` for encoding and decoding features.
 
 ### Supported UUID formats for decoding
+
 ```
    "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
    "6ba7b8109dad11d180b400c04fd430c8"
 ```
 
 ### Supported UUID text representations
+
 ```
    uuid := canonical | hashlike
    plain := canonical | hashlike

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/gofrs/uuid v4.3.1+incompatible
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,9 +7,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- build: update stretchr/testify from v1.8.0 to v1.8.1
- doc: add CI badge
- ci: replace custom implementation of gofmt by golangci-lint
