### PR TITLE
build: add v2 suffix in module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kumojin/go-uuid
+module github.com/kumojin/go-uuid/v2
 
 go 1.17
 


### PR DESCRIPTION
Fix 

```
❯ go get github.com/kumojin/go-uuid@v2.2.0
go: github.com/kumojin/go-uuid@v2.2.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/kumojin/go-uuid/v2")
```