### PR TITLE
Bump CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,22 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ 1.17, 1.18, 1.19, '1.20' ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [ '1.17', '1.18', '1.19', '1.20', '1.21']
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
       - name: Enforce standard format
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.51.2
+          version: v1.55.2
           args: --timeout 3m --enable=gofmt --verbose
       - name: Test
         run: go test --cover -v ./...


### PR DESCRIPTION
- Use fixed version in CI
- Run CI using Go 1.21
- Bump golangci-lint to latest version